### PR TITLE
Fix HTTP request for OpenRouter completions

### DIFF
--- a/evals/util/llm.py
+++ b/evals/util/llm.py
@@ -29,26 +29,28 @@ def get_client() -> OpenAI:
 
 
 def completion(model: str, messages: List[Message]) -> str:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": DEFAULT_MAX_TOKENS,
+        "temperature": DEFAULT_TEMPERATURE,
+        "reasoning": {
+            "exclude": True,
+            "max_tokens": DEFAULT_MAX_REASONING_TOKENS,
+        },
+    }
+
     response = requests.post(
         url="https://openrouter.ai/api/v1/chat/completions",
         headers={
             "Authorization": f"Bearer {ENV.OPENROUTER_API_KEY}",
+            "Content-Type": "application/json",
         },
-        data=json.dumps(
-            {
-                "model": model,
-                "messages": messages,
-                "max_tokens": DEFAULT_MAX_TOKENS,
-                "temperature": DEFAULT_TEMPERATURE,
-                "reasoning": {
-                    "exclude": True,
-                    "max_tokens": DEFAULT_MAX_REASONING_TOKENS,
-                },
-            }
-        ),
+        json=payload,
         timeout=20,
     )
 
+    response.raise_for_status()
     result = response.json()
 
     choice = result["choices"][0]


### PR DESCRIPTION
## Summary
- fix completion API call to send JSON payload with Content-Type header
- raise for HTTP errors before parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684722f6287483209e0b0eaf42643aa2